### PR TITLE
repair broken submodule, add `.gitmodules` for tmux-plugins/tpm@5c4f37a

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tmux/plugins/tpm"]
+	path = tmux/plugins/tpm
+	url = git@github.com:tmux-plugins/tpm.git


### PR DESCRIPTION
Hi! It looks like when you added the Tmux Plugin Manager as a submodule (https://github.com/exergonic/dotfiles/commit/44eb7d477518c73439d2f895a70379dfdc5dc8a5), you didn’t also add a `.gitmodules` file.

This pull request adds the file but does not update the submodule from https://github.com/tmux-plugins/tpm/commit/5c4f37a52d05022d689fb4364a53cfe78d83dc75, the commit it was at when added to this repository.